### PR TITLE
Fix para situação em que botões não respondem ao clique

### DIFF
--- a/src/gui/hidracodeeditor.cpp
+++ b/src/gui/hidracodeeditor.cpp
@@ -162,7 +162,6 @@ void HidraCodeEditor::setCurrentLine(int line)
     QTextCursor cursor(document()->findBlockByNumber(line));
     setTextCursor(cursor);
     ensureCursorVisible();
-    setFocus();
 }
 
 void HidraCodeEditor::wheelEvent(QWheelEvent *e)

--- a/src/gui/hidracodeeditor.cpp
+++ b/src/gui/hidracodeeditor.cpp
@@ -160,6 +160,7 @@ void HidraCodeEditor::setCurrentLine(int line)
         return;
 
     QTextCursor cursor(document()->findBlockByNumber(line));
+    cursor.movePosition(QTextCursor::EndOfLine);
     setTextCursor(cursor);
     ensureCursorVisible();
 }


### PR DESCRIPTION
## Descrição
- Ao usar a opção `Exibir -> Tela segue execução` (habilitada por padrão), os botões da interface não funcionam quando o programa está em loop, dificultando a tarefa de parar o programa.
- A opção `Exibir -> Tela segue execução` agora posiciona o cursor no final da linha para facilitar a edição, ao invés de no início

## Passos para testar
- Para reproduzir o bug, carregue o Hidra original (sem estas alterações):
  - Crie um programa com apenas `JMP 0`, clique Montar e Rodar
  - Os botões Parar etc. não respondem corretamente ao clique enquanto o programa roda
- Faça o teste novamente com as alterações deste PR. O botão deve responder em todos os casos.
- Verifique que o cursor é posicionado no final da próxima linha ao executar um passo (tecla F8)

## Observações
- O programa ainda pode ser parado de outras formas:
  - Se o mouse for movido levemente durante o clique do botão
  - Através do atalho F7
  - Através da opção "Máquina -> Rodar"
  - Desativando a opção `Tela segue execução`