### PR TITLE
Implementação Inicial de Find & Replace

### DIFF
--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -22,6 +22,11 @@ void FindReplaceDialog::clearState()
     ui->replaceTextEdit->clear();
 }
 
+void FindReplaceDialog::onSelectionChange()
+{
+    selected = false;
+}
+
 void FindReplaceDialog::find()
 {
     if (editor->find(ui->findTextEdit->toPlainText())) {
@@ -41,6 +46,7 @@ bool FindReplaceDialog::replace()
     if (selected) {
         editor->insertPlainText(ui->replaceTextEdit->toPlainText());
         selected = false;
+        this->find();
         return true;
     } else {
         return false;
@@ -51,11 +57,18 @@ void FindReplaceDialog::closeEvent(QCloseEvent *evt)
 {
     QDialog::closeEvent(evt);
     this->clearState();
+    editor->unbindFindReplaceDialog();
+}
+
+void FindReplaceDialog::showEvent(QShowEvent *evt)
+{
+    QDialog::showEvent(evt);
+    editor->bindFindReplaceDialog(this);
 }
 
 void FindReplaceDialog::on_findButton_clicked()
 {
-    find();
+    this->find();
 }
 
 void FindReplaceDialog::on_cancelButton_clicked()
@@ -65,7 +78,7 @@ void FindReplaceDialog::on_cancelButton_clicked()
 
 void FindReplaceDialog::on_replaceButton_clicked()
 {
-    editor->insertPlainText(ui->replaceTextEdit->toPlainText());
+    this->replace();
 }
 
 void FindReplaceDialog::on_replaceAllButton_clicked()

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -1,0 +1,30 @@
+#include "findreplacedialog.h"
+#include "ui_findreplacedialog.h"
+
+FindReplaceDialog::FindReplaceDialog(HidraCodeEditor *editor, QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::FindReplaceDialog)
+{
+    ui->setupUi(this);
+    this->editor = editor;
+}
+
+FindReplaceDialog::~FindReplaceDialog()
+{
+    delete ui;
+}
+
+void FindReplaceDialog::on_findButton_clicked()
+{
+     editor->find(ui->findTextEdit->toPlainText());
+}
+
+void FindReplaceDialog::on_cancelButton_clicked()
+{
+    this->close();
+}
+
+void FindReplaceDialog::on_replaceButton_clicked()
+{
+    editor->insertPlainText(ui->replaceTextEdit->toPlainText());
+}

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -342,13 +342,16 @@ QTextDocument::FindFlags FindReplaceDialog::findFlags()
 
 QRegExp FindReplaceDialog::findRegex()
 {
-    QRegExp regex(ui->findTextEdit->toPlainText());
+    Qt::CaseSensitivity caseSensitivity;
     if (ui->caseCheckBox->isChecked()) {
-        regex.setCaseSensitivity(Qt::CaseSensitive);
+        caseSensitivity = Qt::CaseSensitive;
     } else {
-        regex.setCaseSensitivity(Qt::CaseInsensitive);
+        caseSensitivity = Qt::CaseInsensitive;
     }
-    return regex;
+
+    return QRegExp(ui->findTextEdit->toPlainText(),
+                   caseSensitivity,
+                   QRegExp::RegExp2);
 }
 
 void FindReplaceDialog::closeEvent(QCloseEvent *evt)

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -1,6 +1,5 @@
 #include "findreplacedialog.h"
 #include "ui_findreplacedialog.h"
-#include <iostream>
 
 FindReplaceDialog::FindReplaceDialog(HidraCodeEditor *editor, QWidget *parent) :
     QDialog(parent),
@@ -41,6 +40,8 @@ void FindReplaceDialog::updateCounters()
     /* RAII guard */
     ChangingGuard guard = this->changingGuard();
 
+    bool prevSelected = selected;
+
     QTextCursor cursor = editor->textCursor();
     int originalPos = cursor.selectionStart();
     int originalLength = cursor.selectionEnd() - originalPos;
@@ -66,6 +67,8 @@ void FindReplaceDialog::updateCounters()
 
     ui->labelCurrent->setText(QString::number(current));
     ui->labelFound->setText(QString::number(foundCount));
+
+    selected = prevSelected;
 }
 
 bool FindReplaceDialog::findRaw()

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -7,6 +7,7 @@ FindReplaceDialog::FindReplaceDialog(HidraCodeEditor *editor, QWidget *parent) :
 {
     ui->setupUi(this);
     this->editor = editor;
+    selected = false;
 }
 
 FindReplaceDialog::~FindReplaceDialog()
@@ -14,9 +15,47 @@ FindReplaceDialog::~FindReplaceDialog()
     delete ui;
 }
 
+void FindReplaceDialog::clearState()
+{
+    selected = false;
+    ui->findTextEdit->clear();
+    ui->replaceTextEdit->clear();
+}
+
+void FindReplaceDialog::find()
+{
+    if (editor->find(ui->findTextEdit->toPlainText())) {
+        selected = true;
+    } else {
+        editor->moveCursor(QTextCursor::Start);
+        selected = editor->find(ui->findTextEdit->toPlainText());
+    }
+}
+
+bool FindReplaceDialog::replace()
+{
+    if (!selected) {
+        this->find();
+    }
+
+    if (selected) {
+        editor->insertPlainText(ui->replaceTextEdit->toPlainText());
+        selected = false;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void FindReplaceDialog::closeEvent(QCloseEvent *evt)
+{
+    QDialog::closeEvent(evt);
+    this->clearState();
+}
+
 void FindReplaceDialog::on_findButton_clicked()
 {
-     editor->find(ui->findTextEdit->toPlainText());
+    find();
 }
 
 void FindReplaceDialog::on_cancelButton_clicked()
@@ -27,4 +66,9 @@ void FindReplaceDialog::on_cancelButton_clicked()
 void FindReplaceDialog::on_replaceButton_clicked()
 {
     editor->insertPlainText(ui->replaceTextEdit->toPlainText());
+}
+
+void FindReplaceDialog::on_replaceAllButton_clicked()
+{
+    while (this->replace()) {}
 }

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -91,7 +91,7 @@ bool FindReplaceDialog::findRaw()
     ChangingGuard guard(this->changingGuard());
 
     if (ui->regexCheckBox->isChecked()) {
-        QRegularExpression findRegex(this->findRegex());
+        QRegExp findRegex(this->findRegex());
         QTextDocument::FindFlags flags = this->findFlags();
 
         /*
@@ -150,14 +150,15 @@ int FindReplaceDialog::replaceRaw()
     int diff = 0;
 
     if (ui->regexCheckBox->isChecked()) {
-        QRegularExpression findRegex(this->findRegex());
+        QRegExp findRegex(this->findRegex());
         QString selection(editor->textCursor().selectedText());
 
         /*
          * Matches the selection with the regular expression and gets captured
          * groups.
          */
-        QStringList matches(findRegex.match(selection).capturedTexts());
+        findRegex.indexIn(selection);
+        QStringList matches(findRegex.capturedTexts());
 
         /*
          * Expression given by the user to replace the match, using $i to refer
@@ -333,22 +334,20 @@ void FindReplaceDialog::replaceSelection()
 QTextDocument::FindFlags FindReplaceDialog::findFlags()
 {
     QTextDocument::FindFlags flags;
-
     if (ui->caseCheckBox->isChecked()) {
         flags.setFlag(QTextDocument::FindCaseSensitively);
     }
-
     return flags;
 }
 
-QRegularExpression FindReplaceDialog::findRegex()
+QRegExp FindReplaceDialog::findRegex()
 {
-    QRegularExpression regex(ui->findTextEdit->toPlainText());
-    QRegularExpression::PatternOptions options = regex.patternOptions();
-    options.setFlag(QRegularExpression::MultilineOption);
-    options.setFlag(QRegularExpression::CaseInsensitiveOption,
-                    ui->caseCheckBox->isChecked());
-    regex.setPatternOptions(options);
+    QRegExp regex(ui->findTextEdit->toPlainText());
+    if (ui->caseCheckBox->isChecked()) {
+        regex.setCaseSensitivity(Qt::CaseSensitive);
+    } else {
+        regex.setCaseSensitivity(Qt::CaseInsensitive);
+    }
     return regex;
 }
 

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -27,6 +27,11 @@ void FindReplaceDialog::onSelectionChange()
     selected = false;
 }
 
+int FindReplaceDialog::replaceSizeDiff()
+{
+    return ui->replaceTextEdit->toPlainText().length() - ui->findTextEdit->toPlainText().length();
+}
+
 void FindReplaceDialog::find()
 {
     if (editor->find(ui->findTextEdit->toPlainText())) {
@@ -37,7 +42,7 @@ void FindReplaceDialog::find()
     }
 }
 
-bool FindReplaceDialog::replace()
+void FindReplaceDialog::replace()
 {
     if (!selected) {
         this->find();
@@ -47,9 +52,86 @@ bool FindReplaceDialog::replace()
         editor->insertPlainText(ui->replaceTextEdit->toPlainText());
         selected = false;
         this->find();
-        return true;
-    } else {
-        return false;
+    }
+}
+
+void FindReplaceDialog::replaceAll()
+{
+    /*
+     * Difference between sizes of replace text and find text, required to
+     * recompute positions when a substitution happens.
+     */
+    int sizeDiff = this->replaceSizeDiff();
+
+    /* Position where we started. */
+    QTextCursor cursor = editor->textCursor();
+    int originalPos = cursor.selectionStart();
+
+    /* Selects something if not selected. */
+    if (!selected) {
+        this->find();
+    }
+
+    /* Start and end of the first selection. */
+    cursor = editor->textCursor();
+    int lastPosStart = cursor.selectionStart();
+    int lastPosEnd = cursor.selectionEnd();
+
+    /* We need to keep track if the selection is reaching original position. */
+    bool inBounds = true;
+
+    while (selected && inBounds) {
+        /*
+         * Adjust original position due to replace below.
+         *
+         * It is ok to perform this if no selection is found after the
+         * replacement. We can compute inBounds below, and even if it is
+         * true, the object's selected attribute will be false next iteration,
+         * and all we do until then is to compute inBounds.
+         */
+        if (originalPos > lastPosStart) {
+            originalPos += sizeDiff;
+        }
+
+        /*
+         * Required since we are replacing text in position given by lastPos.
+         */
+        lastPosEnd += sizeDiff;
+
+        this->replace();
+
+        /* Position of the selection AFTER the replacement above. */
+        cursor = editor->textCursor();
+        int currPosStart = cursor.selectionStart();
+        int currPosEnd = cursor.selectionEnd();
+
+        /* We assume it is false by default. */
+        inBounds = false;
+
+        /* Only true if one of the following conditions hold. */
+        if (currPosStart > lastPosStart && lastPosStart >= originalPos) {
+            inBounds = true;
+        } else if (lastPosStart >= originalPos && originalPos > currPosStart) {
+            inBounds = true;
+        } else if (originalPos > currPosStart && currPosStart > lastPosStart) {
+            inBounds = true;
+        }
+
+        /*
+         * inBounds will only be true if one of the conditions above happens,
+         * and if any of the ones below is true, inBounds will be false again.
+         */
+        if (currPosEnd > originalPos && originalPos > currPosStart) {
+            inBounds = false;
+        } else if (currPosEnd > lastPosEnd && lastPosEnd > currPosStart) {
+            inBounds = false;
+        } else if (currPosEnd > lastPosStart && lastPosStart > currPosStart) {
+            inBounds = false;
+        }
+
+        /* Now the last selection is the current one. */
+        lastPosStart = currPosStart;
+        lastPosEnd = currPosEnd;
     }
 }
 
@@ -83,5 +165,5 @@ void FindReplaceDialog::on_replaceButton_clicked()
 
 void FindReplaceDialog::on_replaceAllButton_clicked()
 {
-    while (this->replace()) {}
+    this->replaceAll();
 }

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -31,8 +31,17 @@ void FindReplaceDialog::onSelectionChange()
 {
     if (changingCount == 0) {
         selected = false;
-        this->updateCounters();
+        this->clearCounters();
     }
+}
+
+void FindReplaceDialog::clearCounters()
+{
+    foundCount = 0;
+    current = 0;
+
+    ui->labelCurrent->setText(QString::number(current));
+    ui->labelFound->setText(QString::number(foundCount));
 }
 
 void FindReplaceDialog::updateCounters()
@@ -250,7 +259,7 @@ void FindReplaceDialog::showEvent(QShowEvent *evt)
 {
     QDialog::showEvent(evt);
     editor->bindFindReplaceDialog(this);
-    this->updateCounters();
+    this->clearCounters();
 }
 
 void FindReplaceDialog::on_findButton_clicked()

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -346,9 +346,8 @@ QRegularExpression FindReplaceDialog::findRegex()
     QRegularExpression regex(ui->findTextEdit->toPlainText());
     QRegularExpression::PatternOptions options = regex.patternOptions();
     options.setFlag(QRegularExpression::MultilineOption);
-    if (ui->caseCheckBox->isChecked()) {
-        options.setFlag(QRegularExpression::CaseInsensitiveOption, false);
-    }
+    options.setFlag(QRegularExpression::CaseInsensitiveOption,
+                    ui->caseCheckBox->isChecked());
     regex.setPatternOptions(options);
     return regex;
 }

--- a/src/gui/findreplacedialog.cpp
+++ b/src/gui/findreplacedialog.cpp
@@ -104,29 +104,7 @@ int FindReplaceDialog::replaceRaw()
         QString replaceText(pieces[0]);
 
         for (int i = 1; i < pieces.length(); i++) {
-            int cut = 0;
-            int group = 0;
-            bool inBounds = true;
-            bool hasGroup = false;
-
-            while (cut < pieces[i].length() && pieces[i][cut].isDigit() && inBounds) {
-                int newGroup = group * 10 + pieces[i][cut].digitValue();
-                inBounds = newGroup < matches.length();
-                if (inBounds) {
-                    group = newGroup;
-                    hasGroup = true;
-                    cut++;
-                }
-            }
-
-            if (pieces[i].length() == 0) {
-                replaceText += '$';
-            } else {
-                if (hasGroup) {
-                    replaceText += matches[group];
-                }
-                replaceText += pieces[i].rightRef(pieces[i].length() - cut);
-            }
+            this->appendRegexPiece(replaceText, pieces[i], matches);
         }
 
         editor->insertPlainText(replaceText);
@@ -140,6 +118,33 @@ int FindReplaceDialog::replaceRaw()
 
     selected = false;
     return diff;
+}
+
+void FindReplaceDialog::appendRegexPiece(QString &replaceText, QString const &piece, QStringList const &matches)
+{
+    if (piece.length() == 0) {
+        replaceText += '$';
+    } else {
+        int cut = 0;
+        int group = 0;
+        bool inBounds = true;
+        bool hasGroup = false;
+
+        while (cut < piece.length() && piece[cut].isDigit() && inBounds) {
+            int newGroup = group * 10 + piece[cut].digitValue();
+            inBounds = newGroup < matches.length();
+            if (inBounds) {
+                group = newGroup;
+                hasGroup = true;
+                cut++;
+            }
+        }
+
+        if (hasGroup) {
+            replaceText += matches[group];
+        }
+        replaceText += piece.rightRef(piece.length() - cut);
+    }
 }
 
 void FindReplaceDialog::find()

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -1,0 +1,31 @@
+#ifndef FINDREPLACEDIALOG_H
+#define FINDREPLACEDIALOG_H
+
+#include <QDialog>
+#include "hidracodeeditor.h"
+
+namespace Ui {
+class FindReplaceDialog;
+}
+
+class FindReplaceDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit FindReplaceDialog(HidraCodeEditor *editor, QWidget *parent = nullptr);
+    ~FindReplaceDialog();
+
+private slots:
+    void on_cancelButton_clicked();
+
+    void on_findButton_clicked();
+
+    void on_replaceButton_clicked();
+
+private:
+    Ui::FindReplaceDialog *ui;
+    HidraCodeEditor *editor;
+};
+
+#endif // FINDREPLACEDIALOG_H

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -41,6 +41,7 @@ private:
     int foundCount;
 
     void updateCounters();
+    void clearCounters();
 
     bool findRaw();
     int replaceRaw();

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -47,6 +47,8 @@ private:
     void replace();
     void replaceAll();
 
+    QTextDocument::FindFlags findFlags();
+
     /*
      * This is a RAII guard, in order to prevent the onSelectionChange method
      * from performing its actions when the FindReplaceDialog itself is changing

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -26,6 +26,7 @@ private slots:
     void on_findButton_clicked();
     void on_replaceButton_clicked();
     void on_replaceAllButton_clicked();
+    void on_replaceSelected_clicked();
 
 protected:
     virtual void closeEvent(QCloseEvent *evt);
@@ -46,6 +47,7 @@ private:
     void find();
     void replace();
     void replaceAll();
+    void replaceSelection();
 
     QTextDocument::FindFlags findFlags();
 

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -42,7 +42,8 @@ private:
 
     void updateCounters();
 
-    int replaceSizeDiff();
+    bool findRaw();
+    int replaceRaw();
 
     void find();
     void replace();

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -43,7 +43,12 @@ private:
     void updateCounters();
     void clearCounters();
 
+    /* Finds the searched text and returns if found. No wrap-around. */
     bool findRaw();
+    /*
+     * Replaces selected text and returns the difference between the size of
+     * the replaced text and the searched text.
+     */
     int replaceRaw();
 
     void find();
@@ -52,16 +57,18 @@ private:
     void replaceSelection();
 
     QTextDocument::FindFlags findFlags();
+    QRegularExpression findRegex();
 
     /*
      * Adds a piece of regex replace command. Pieces must have been split where
-     * a '$' would occur. This means that in the original string, the piece was
-     * preceeded by '$'. It transforms things (in the original string) like '$1'
-     * into the text captured by the first group of the regex.
+     * a '$' would occur, and it cannot be empty. This means that in the
+     * original string, the piece was preceeded by '$'. It transforms things
+     * (in the original string) like '$1' into the text captured by the first
+     * group of the regex.
      *
      * This function exists solely to make replaceRaw() not so big.
      */
-    void appendRegexPiece(QString &replaceText, QString const &piece, QStringList const &matches);
+    void replaceRegexParam(QString &replaceText, QString const &piece, QStringList const &matches);
 
     /*
      * This is a RAII guard, in order to prevent the onSelectionChange method

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -57,7 +57,7 @@ private:
     void replaceSelection();
 
     QTextDocument::FindFlags findFlags();
-    QRegularExpression findRegex();
+    QRegExp findRegex();
 
     /*
      * Adds a piece of regex replace command. Pieces must have been split where

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -36,8 +36,11 @@ private:
     HidraCodeEditor *editor;
     bool selected;
 
+    int replaceSizeDiff();
+
     void find();
-    bool replace();
+    void replace();
+    void replaceAll();
 };
 
 #endif // FINDREPLACEDIALOG_H

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -35,12 +35,42 @@ private:
     Ui::FindReplaceDialog *ui;
     HidraCodeEditor *editor;
     bool selected;
+    int changingCount;
+    int current;
+    int foundCount;
+
+    void updateCounters();
 
     int replaceSizeDiff();
 
     void find();
     void replace();
     void replaceAll();
+
+    /*
+     * This is a RAII guard, in order to prevent the onSelectionChange method
+     * from performing its actions when the FindReplaceDialog itself is changing
+     * the editor.
+     *
+     * This increments the counter on construction, decrements when out of
+     * scope (destroyed).
+     *
+     * To use this, just place
+     *
+     * ChangingGuard guard = this->changingGuard();
+     *
+     * on the top of the scope. It automatically is deleted at the end of the
+     * scope.
+     */
+    class ChangingGuard {
+    public:
+        ChangingGuard(int &count);
+        ~ChangingGuard();
+    private:
+        int &count;
+    };
+
+    ChangingGuard changingGuard();
 };
 
 #endif // FINDREPLACEDIALOG_H

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -53,6 +53,16 @@ private:
     QTextDocument::FindFlags findFlags();
 
     /*
+     * Adds a piece of regex replace command. Pieces must have been split where
+     * a '$' would occur. This means that in the original string, the piece was
+     * preceeded by '$'. It transforms things (in the original string) like '$1'
+     * into the text captured by the first group of the regex.
+     *
+     * This function exists solely to make replaceRaw() not so big.
+     */
+    void appendRegexPiece(QString &replaceText, QString const &piece, QStringList const &matches);
+
+    /*
      * This is a RAII guard, in order to prevent the onSelectionChange method
      * from performing its actions when the FindReplaceDialog itself is changing
      * the editor.

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -16,6 +16,8 @@ public:
     explicit FindReplaceDialog(HidraCodeEditor *editor, QWidget *parent = nullptr);
     ~FindReplaceDialog();
 
+    void clearState();
+
 private slots:
     void on_cancelButton_clicked();
 
@@ -23,9 +25,18 @@ private slots:
 
     void on_replaceButton_clicked();
 
+    void on_replaceAllButton_clicked();
+
+protected:
+     virtual void closeEvent(QCloseEvent *evt);
+
 private:
     Ui::FindReplaceDialog *ui;
     HidraCodeEditor *editor;
+    bool selected;
+
+    void find();
+    bool replace();
 };
 
 #endif // FINDREPLACEDIALOG_H

--- a/src/gui/findreplacedialog.h
+++ b/src/gui/findreplacedialog.h
@@ -18,17 +18,18 @@ public:
 
     void clearState();
 
+public slots:
+    void onSelectionChange();
+
 private slots:
     void on_cancelButton_clicked();
-
     void on_findButton_clicked();
-
     void on_replaceButton_clicked();
-
     void on_replaceAllButton_clicked();
 
 protected:
-     virtual void closeEvent(QCloseEvent *evt);
+    virtual void closeEvent(QCloseEvent *evt);
+    virtual void showEvent(QShowEvent *evt);
 
 private:
     Ui::FindReplaceDialog *ui;

--- a/src/gui/findreplacedialog.ui
+++ b/src/gui/findreplacedialog.ui
@@ -216,7 +216,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="pushButton">
+       <widget class="QPushButton" name="replaceSelected">
         <property name="text">
          <string>Substiuir Selecionado</string>
         </property>

--- a/src/gui/findreplacedialog.ui
+++ b/src/gui/findreplacedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>510</width>
-    <height>387</height>
+    <height>411</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,7 +19,7 @@
      <x>9</x>
      <y>9</y>
      <width>491</width>
-     <height>371</height>
+     <height>391</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -150,6 +150,27 @@
      </layout>
     </item>
     <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="caseCheckBox">
+        <property name="text">
+         <string>Minusc vs Maiusc</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="regexCheckBox">
+        <property name="text">
+         <string>Expressões Regulares</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
      <spacer name="horizontalSpacer_2">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
@@ -191,6 +212,13 @@
        <widget class="QPushButton" name="replaceAllButton">
         <property name="text">
          <string>Substituir Tudo</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButton">
+        <property name="text">
+         <string>Substiuir Selecionado</string>
         </property>
        </widget>
       </item>

--- a/src/gui/findreplacedialog.ui
+++ b/src/gui/findreplacedialog.ui
@@ -87,7 +87,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="label_4">
+       <widget class="QLabel" name="labelCurrent">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -104,7 +104,7 @@
          <enum>Qt::RightToLeft</enum>
         </property>
         <property name="text">
-         <string>x/y</string>
+         <string>x</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -114,6 +114,20 @@
         </property>
         <property name="indent">
          <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>/</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelFound">
+        <property name="text">
+         <string>y</string>
         </property>
        </widget>
       </item>

--- a/src/gui/findreplacedialog.ui
+++ b/src/gui/findreplacedialog.ui
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FindReplaceDialog</class>
+ <widget class="QDialog" name="FindReplaceDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>510</width>
+    <height>387</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>9</y>
+     <width>491</width>
+     <height>371</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Busca:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPlainTextEdit" name="findTextEdit"/>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="findButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Buscar</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Minimum</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Encontrado:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="sizeIncrement">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string>x/y</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+        <property name="indent">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Minimum</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <spacer name="horizontalSpacer_2">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QLabel" name="label_2">
+      <property name="text">
+       <string>Substituição:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPlainTextEdit" name="replaceTextEdit"/>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="replaceButton">
+        <property name="text">
+         <string>Substituir</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="replaceAllButton">
+        <property name="text">
+         <string>Substituir Tudo</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>10</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QPushButton" name="cancelButton">
+      <property name="text">
+       <string>Cancelar</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/hidracodeeditor.cpp
+++ b/src/gui/hidracodeeditor.cpp
@@ -170,8 +170,10 @@ void HidraCodeEditor::setCurrentLine(int line)
 
 void HidraCodeEditor::bindFindReplaceDialog(FindReplaceDialog *dialog)
 {
+    this->unbindFindReplaceDialog();
     findReplaceDialog = dialog;
-    if (findReplaceDialog != nullptr) {
+
+    if (dialog != nullptr) {
         connect(this,
                 &HidraCodeEditor::selectionChanged,
                 findReplaceDialog,

--- a/src/gui/hidracodeeditor.cpp
+++ b/src/gui/hidracodeeditor.cpp
@@ -1,4 +1,5 @@
 #include "hidracodeeditor.h"
+#include "findreplacedialog.h"
 
 HidraCodeEditor::HidraCodeEditor(QWidget *parent) : QPlainTextEdit(parent)
 {
@@ -26,6 +27,8 @@ HidraCodeEditor::HidraCodeEditor(QWidget *parent) : QPlainTextEdit(parent)
 
     updateLineNumberAreaWidth(0);
     //highlightCurrentLine();
+
+    findReplaceDialog = nullptr;
 }
 
 int HidraCodeEditor::lineNumberAreaWidth()
@@ -163,6 +166,36 @@ void HidraCodeEditor::setCurrentLine(int line)
     setTextCursor(cursor);
     ensureCursorVisible();
     setFocus();
+}
+
+void HidraCodeEditor::bindFindReplaceDialog(FindReplaceDialog *dialog)
+{
+    findReplaceDialog = dialog;
+    if (findReplaceDialog != nullptr) {
+        connect(this,
+                &HidraCodeEditor::selectionChanged,
+                findReplaceDialog,
+                &FindReplaceDialog::onSelectionChange);
+        connect(this,
+                &HidraCodeEditor::textChanged,
+                findReplaceDialog,
+                &FindReplaceDialog::onSelectionChange);
+    }
+}
+
+void HidraCodeEditor::unbindFindReplaceDialog()
+{
+    if (findReplaceDialog != nullptr) {
+        disconnect(this,
+                   &HidraCodeEditor::selectionChanged,
+                   findReplaceDialog,
+                   &FindReplaceDialog::onSelectionChange);
+        disconnect(this,
+                   &HidraCodeEditor::textChanged,
+                   findReplaceDialog,
+                   &FindReplaceDialog::onSelectionChange);
+        findReplaceDialog = nullptr;
+    }
 }
 
 void HidraCodeEditor::wheelEvent(QWheelEvent *e)

--- a/src/gui/hidracodeeditor.h
+++ b/src/gui/hidracodeeditor.h
@@ -11,6 +11,8 @@
 
 class LineNumberArea;
 
+class FindReplaceDialog;
+
 class HidraCodeEditor : public QPlainTextEdit
 {
     Q_OBJECT
@@ -26,11 +28,11 @@ public:
     void clearBreakpoint();
     void disableLineHighlight();
     void setCurrentLine(int line);
+    void bindFindReplaceDialog(FindReplaceDialog *dialog);
+    void unbindFindReplaceDialog();
 
     void wheelEvent(QWheelEvent *e);
     virtual void clear();
-
-public slots:
 
 protected:
     void resizeEvent(QResizeEvent *event);
@@ -43,6 +45,7 @@ private slots:
 private:
     QWidget *lineNumberArea;
     QTextBlock breakpointBlock;
+    FindReplaceDialog *findReplaceDialog;
 };
 
 

--- a/src/gui/hidragui.cpp
+++ b/src/gui/hidragui.cpp
@@ -38,6 +38,7 @@ HidraGui::HidraGui(QWidget *parent) :
 
     codeEditor  = new HidraCodeEditor();
     highlighter = new HidraHighlighter(codeEditor->document());
+    findReplaceDialog = new FindReplaceDialog(codeEditor);
     ui->layoutSourceCodeHolder->addWidget(codeEditor);
     connect(codeEditor, SIGNAL(textChanged()), this, SLOT(sourceCodeChanged()));
     about = new About();
@@ -95,6 +96,7 @@ HidraGui::~HidraGui()
 {
     delete about;
     delete ui;
+    delete findReplaceDialog;
 }
 
 
@@ -1434,4 +1436,9 @@ void HidraGui::on_tableViewMemoryData_doubleClicked(const QModelIndex &index)
 
     if (addressCorrespondingSourceLine != -1)
         codeEditor->setCurrentLine(addressCorrespondingSourceLine);
+}
+
+void HidraGui::on_actionFindReplace_triggered()
+{
+    findReplaceDialog->show();
 }

--- a/src/gui/hidragui.h
+++ b/src/gui/hidragui.h
@@ -15,6 +15,7 @@
 #include "hidracodeeditor.h"
 #include "hidrahighlighter.h"
 #include "registerwidget.h"
+#include "findreplacedialog.h"
 #include "flagwidget.h"
 #include "about.h"
 #include "machines/neandermachine.h"
@@ -129,6 +130,8 @@ private slots:
     void on_tableViewMemoryInstructions_doubleClicked(const QModelIndex &index);
     void on_tableViewMemoryData_doubleClicked(const QModelIndex &index);
 
+    void on_actionFindReplace_triggered();
+
 private:
     // Internal initialize methods (called by initializeMachineInterface)
     void initializeMachineInterfaceComponents();
@@ -173,6 +176,7 @@ private:
     Machine *machine;
     HidraHighlighter *highlighter;
     HidraCodeEditor *codeEditor;
+    FindReplaceDialog *findReplaceDialog;
     QVector<FlagWidget*> flagWidgets;
     QVector<RegisterWidget*> registerWidgets;
     About *about;

--- a/src/gui/hidragui.ui
+++ b/src/gui/hidragui.ui
@@ -325,8 +325,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>279</width>
-               <height>69</height>
+               <width>275</width>
+               <height>68</height>
               </rect>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -697,7 +697,7 @@
      <x>0</x>
      <y>0</y>
      <width>1115</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuProgram">
@@ -745,6 +745,7 @@
     <addaction name="separator"/>
     <addaction name="actionFastExecuteMode"/>
     <addaction name="actionFollowPCMode"/>
+    <addaction name="actionFindReplace"/>
    </widget>
    <addaction name="menuProgram"/>
    <addaction name="menuMemory"/>
@@ -1018,6 +1019,11 @@
    </property>
    <property name="shortcut">
     <string>F6</string>
+   </property>
+  </action>
+  <action name="actionFindReplace">
+   <property name="text">
+    <string>Buscar e Substituir</string>
    </property>
   </action>
  </widget>

--- a/src/gui/hidragui.ui
+++ b/src/gui/hidragui.ui
@@ -325,8 +325,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>277</width>
-               <height>78</height>
+               <width>275</width>
+               <height>68</height>
               </rect>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -697,7 +697,7 @@
      <x>0</x>
      <y>0</y>
      <width>1115</width>
-     <height>28</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuProgram">
@@ -745,6 +745,7 @@
     <addaction name="separator"/>
     <addaction name="actionFastExecuteMode"/>
     <addaction name="actionFollowPCMode"/>
+    <addaction name="separator"/>
     <addaction name="actionFindReplace"/>
    </widget>
    <addaction name="menuProgram"/>

--- a/src/hidra.pro
+++ b/src/hidra.pro
@@ -15,6 +15,7 @@ CONFIG  += \
     c++11
 
 SOURCES += \
+    gui/findreplacedialog.cpp \
     gui/flagwidget.cpp \
     gui/hidracodeeditor.cpp \
     gui/hidragui.cpp \
@@ -39,6 +40,7 @@ SOURCES += \
     gui/about.cpp
 
 HEADERS  += \
+    gui/findreplacedialog.h \
     gui/flagwidget.h \
     gui/hidracodeeditor.h \
     gui/hidragui.h \
@@ -62,6 +64,7 @@ HEADERS  += \
     gui/about.h
 
 FORMS    += \
+    gui/findreplacedialog.ui \
     gui/flagwidget.ui \
     gui/hidragui.ui \
     gui/registerwidget.ui \


### PR DESCRIPTION
# Descrição
Foi proposto no grupo que implementássemos uma funcionalidade de Find & Replace no editor de texto. Para tanto, foi implementado em forma de um _dialog_, com suporte à buscar por texto simples ou expressões regulares, bem como suporte a ignorar caixa ou ser sensível à caixa. Além disso, foi dado suporte para substituir uma vez o texto selecionado, subsituir todas ocorrências, ou substituir somente na seleção. Por último, o _dialog_ exibe a contagem `atual/total` de trechos encontrados (antes da primeira busca, `?/?` é exibido).

# Passos Para Testar
Insira um código de exemplo:
```
org 128

input_a:
	db 0
input_b:
	db 0
output:
	db 0
count:
	db 0
zero:
	db 0
minusOne:
	db 255

org 0
	lda zero
	sta output
	lda input_a

loop:
	jz end
	add minusOne
	sta count
	lda output
	add input_b
	sta output
	lda count
	jmp loop

end:
	hlt
```
- Coloque o mouse na linha `lda output` (dentro de `loop:`).
- Aperte `Ctrl-F`, ou vá para `Exibir > Buscar e Substituir`. 
- Digite "output" na caixa "Busca:".
- Aperte o botão "Buscar" quantas vezes quiser, e observe a contagem de "Encontrado:" mudar.
- Agora, preencha a caixa de "Substituição:" com "out_a".
- Clique em "Substituir" até que todas as ocorrências tenham sido substituídas, e observe que as mudanças ocorrem uma a uma, parcialmente.
- Feche o _dialog_, seja pelo sistema de janelas do seu OS, seja em "Cancelar".
- Selecione tudo entre `loop:` e `end:`.
- Novamente,  aperte `Ctrl-F`, ou vá para `Exibir > Buscar e Substituir`.
- Perceba que o _dialog_ está "resetado".
- Insira "count" na caixa "Busca:".
- Insira "iterator" na caixa "Substituição:"
- Mantenha a seleção, e clique em "Substituir Selecionado".
- Observe que a substituição só ocorre dentro da seleção.
- Ligue a opção "Maiusc vs. Minusc".
- Troque o texto em "Busca:" por "COUNT".
- Tente buscar e perceba que não encontrou-se nada.
- Desative a opção.
- Busque e perceba que encontram-se resultados.
- Clique no botão "Substituir Tudo".
- Perceba que o restante das ocorrências de "count" foram substituídas.
- Troque a busca por "input_" e a substituição por "in_".
- Clique em "Substituir Tudo" e veja todas as ocorrências sendo substituídas.
- Ligue a opção "Expressões Regulares".
- Coloque `([a-zA-Z]*)_([a-zA-Z]*)(:?)` na entrada "Buscar:".
- Busque e note que são encontrados identificadores no formato `foo_bar`, junto com um `:` se houver.
- Coloque `$2_$1$3 ; $$ = $0` na entrada "Substituição:".
- Clique em substituir tudo.
- Note que `in_a`, por exemplo, tornou-se `a_in ; $ = in_a`.

O resultado final deve parecer-se com:
```
org 128

a_in: ; $ = in_a:
	db 0
b_in: ; $ = in_b:
	db 0
a_out: ; $ = out_a:
	db 0
iterator:
	db 0
zero:
	db 0
minusOne:
	db 255

org 0
	lda zero
	sta a_out ; $ = out_a
	lda a_in ; $ = in_a

loop:$
	jz end
	add minusOne
	sta iterator
	lda a_out ; $ = out_a
	add b_in ; $ = in_b
	sta a_out ; $ = out_a
	lda iterator
	jmp loop

end:
	hlt
```
# Observações
- Texto de substituição de Regex tem caracter `$` como especial:
  - `$$` é substituído por um só `$`
  - `$0` é substituído por toda captura.
  - `$n` é substituído pelo conteúdo do grupo `n` (começa no `1`).