### PR TITLE
Fix para a diretiva ORG aceitar valores em hexadecimal

### DIFF
--- a/src/core/machine.cpp
+++ b/src/core/machine.cpp
@@ -556,10 +556,8 @@ void Machine::obeyDirective(QString mnemonic, QString arguments, bool reserveOnl
             throw invalidAddress;
 
         if (arguments[0] == 'h' || arguments[0] == 'H'){
-            bool ok = true;
             arguments[0] = '0';
-            int end = arguments.toInt(&ok, 16);
-            PC->setValue(end);
+            PC->setValue(arguments.toInt(NULL, 16));
         } else
             PC->setValue(argumentList.first().toInt(0));
     }

--- a/src/core/machine.cpp
+++ b/src/core/machine.cpp
@@ -555,7 +555,13 @@ void Machine::obeyDirective(QString mnemonic, QString arguments, bool reserveOnl
         if (!isValidOrg(argumentList.first()))
             throw invalidAddress;
 
-        PC->setValue(argumentList.first().toInt(0));
+        if (arguments[0] == 'h' || arguments[0] == 'H'){
+            bool ok = true;
+            arguments[0] = '0';
+            int end = arguments.toInt(&ok, 16);
+            PC->setValue(end);
+        } else
+            PC->setValue(argumentList.first().toInt(0));
     }
     else if (QRegExp("db|dw|dab|daw").exactMatch(mnemonic))
     {

--- a/src/core/machine.cpp
+++ b/src/core/machine.cpp
@@ -555,11 +555,7 @@ void Machine::obeyDirective(QString mnemonic, QString arguments, bool reserveOnl
         if (!isValidOrg(argumentList.first()))
             throw invalidAddress;
 
-        if (arguments[0] == 'h' || arguments[0] == 'H'){
-            arguments[0] = '0';
-            PC->setValue(arguments.toInt(NULL, 16));
-        } else
-            PC->setValue(argumentList.first().toInt(0));
+        PC->setValue(stringToInt(argumentList.first()));
     }
     else if (QRegExp("db|dw|dab|daw").exactMatch(mnemonic))
     {


### PR DESCRIPTION
### Descrição
- Problema trazido em  #15 
- Quando utilizada a diretiva `org` com um parâmetro em representação hexadecimal, ao invés de ser interpretado como hexadecimal o parâmetro é colocado no endereço de memória 0.
- A diretiva `org` agora interpreta valores em notação hexadecimal.

### Passos para testar
- Para reproduzir o bug, carregue o Hidra original (sem estas alterações):
    - Crie um programa com `ORG h10`  e `DB 88`, como na imagem abaixo. 
    - O valor "88" é posicionado na endereço de memória 0.
   
![image](https://user-images.githubusercontent.com/57200997/111358861-97b76a00-8669-11eb-9923-7a8ed16ad885.png)
- Faça o teste novamente com as alterações deste PR. O valor "88" agora está posicionado no endereço de memória 10.
