### PR TITLE
Machine runtime parameters

### DIFF
--- a/src/core/machine.cpp
+++ b/src/core/machine.cpp
@@ -93,14 +93,14 @@ void Machine::executeInstruction(Instruction *&instruction, AddressingMode::Addr
     //////////////////////////////////////////////////
 
     case Instruction::LDR:
-        result = memoryGetOperandValue();
+        result = GetCurrentOperandValue();
         setRegisterValue(registerName, result);
         updateFlags(result);
         break;
 
     case Instruction::STR:
         result = getRegisterValue(registerName);
-        memoryWrite(memoryGetOperandAddress(), result);
+        memoryWrite(GetCurrentOperandAddress(), result);
         break;
 
 
@@ -111,7 +111,7 @@ void Machine::executeInstruction(Instruction *&instruction, AddressingMode::Addr
 
     case Instruction::ADD:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue();
+        value2 = GetCurrentOperandValue();
         result = (value1 + value2) & 0xFF;
 
         setRegisterValue(registerName, result);
@@ -122,7 +122,7 @@ void Machine::executeInstruction(Instruction *&instruction, AddressingMode::Addr
 
     case Instruction::OR:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue();
+        value2 = GetCurrentOperandValue();
         result = (value1 | value2);
 
         setRegisterValue(registerName, result);
@@ -131,7 +131,7 @@ void Machine::executeInstruction(Instruction *&instruction, AddressingMode::Addr
 
     case Instruction::AND:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue();
+        value2 = GetCurrentOperandValue();
         result = (value1 & value2);
 
         setRegisterValue(registerName, result);
@@ -148,7 +148,7 @@ void Machine::executeInstruction(Instruction *&instruction, AddressingMode::Addr
 
     case Instruction::SUB:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue();
+        value2 = GetCurrentOperandValue();
         result = (value1 - value2) & 0xFF;
 
         setRegisterValue(registerName, result);
@@ -217,63 +217,63 @@ void Machine::executeInstruction(Instruction *&instruction, AddressingMode::Addr
 
     case Instruction::JMP:
         if (!isImmediate) // Invalidate immediate jumps
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JN:
         if (getFlagValue("N") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JP:
         if (getFlagValue("N") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JV:
         if (getFlagValue("V") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JNV:
         if (getFlagValue("V") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JZ:
         if (getFlagValue("Z") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JNZ:
         if (getFlagValue("Z") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JC:
         if (getFlagValue("C") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JNC:
         if (getFlagValue("C") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JB:
         if (getFlagValue("B") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JNB:
         if (getFlagValue("B") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JSR:
         if (!isImmediate)
         {
-            int jumpAddress = memoryGetJumpAddress();
+            int jumpAddress = GetCurrentJumpAddress();
             memoryWrite(jumpAddress, getPCValue());
             setPCValue(jumpAddress+1);
         }
@@ -1027,7 +1027,7 @@ int Machine::memoryReadNext()
     return value;
 }
 
-int Machine::memoryGetOperandAddress()
+int Machine::GetCurrentOperandAddress()
 {
 
     int immediateAddress = decodedImmediateAddress; 
@@ -1055,14 +1055,14 @@ int Machine::memoryGetOperandAddress()
     }
 }
 
-int Machine::memoryGetOperandValue()
+int Machine::GetCurrentOperandValue()
 {
-    return memoryRead(memoryGetOperandAddress()); // Return 1-byte value
+    return memoryRead(GetCurrentOperandAddress()); // Return 1-byte value
 }
 
-int Machine::memoryGetJumpAddress()
+int Machine::GetCurrentJumpAddress()
 {
-    return memoryGetOperandAddress();
+    return GetCurrentOperandAddress();
 }
 
 

--- a/src/core/machine.h
+++ b/src/core/machine.h
@@ -130,9 +130,9 @@ public:
     void memoryWrite(int address, int value); // Increments accessCount
     int  memoryReadNext(); // Returns value pointed to by PC, then increments PC; Increments accessCount
 
-    virtual int memoryGetOperandAddress(); // increments accessCount
-    int memoryGetOperandValue(); // increments accessCount
-    int memoryGetJumpAddress(); // increments accessCount
+    virtual int GetCurrentOperandAddress(); // increments accessCount
+    int GetCurrentOperandValue(); // increments accessCount
+    int GetCurrentJumpAddress(); // increments accessCount
 
 
 

--- a/src/core/machine.h
+++ b/src/core/machine.h
@@ -130,9 +130,9 @@ public:
     void memoryWrite(int address, int value); // Increments accessCount
     int  memoryReadNext(); // Returns value pointed to by PC, then increments PC; Increments accessCount
 
-    virtual int memoryGetOperandAddress(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode); // increments accessCount
-    int memoryGetOperandValue(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode); // increments accessCount
-    int memoryGetJumpAddress( int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode); // increments accessCount
+    virtual int memoryGetOperandAddress(); // increments accessCount
+    int memoryGetOperandValue(); // increments accessCount
+    int memoryGetJumpAddress(); // increments accessCount
 
 
 

--- a/src/machines/periclesmachine.cpp
+++ b/src/machines/periclesmachine.cpp
@@ -78,24 +78,28 @@ int PericlesMachine::calculateBytesToReserve(QString addressArgument)
     return (addressingModeCode == AddressingMode::IMMEDIATE) ? 2 : 3; // Immediate requires only 2 bytes
 }
 
-void PericlesMachine::decodeInstruction(int fetchedValue, Instruction *&instruction, AddressingMode::AddressingModeCode &addressingModeCode, QString &registerName, int &immediateAddress)
-{
-    addressingModeCode = extractAddressingModeCode(fetchedValue);
-    registerName = extractRegisterName(fetchedValue);
+void PericlesMachine::decodeInstruction(){
+    
+    decodedAdressingModeCode1 = extractAddressingModeCode(fetchedValue);
+    decodedRegisterName1 = extractRegisterName(fetchedValue);
 
-    if (instruction && instruction->getNumBytes() == 0) // If instruction has variable number of bytes
+    if (currentInstruction && currentInstruction->getNumBytes() == 0) // If instruction has variable number of bytes
     {
-        immediateAddress = getPCValue(); // Address that contains first argument byte
+        decodedImmediateAddress = getPCValue(); // Address that contains first argument byte
 
         // Skip argument bytes
         incrementPCValue();
-        if (addressingModeCode != AddressingMode::IMMEDIATE) // Immediate argument has only 1 byte
+        if (decodedAdressingModeCode1 != AddressingMode::IMMEDIATE) // Immediate argument has only 1 byte
             incrementPCValue();
     }
 }
 
-int PericlesMachine::memoryGetOperandAddress(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode)
+int PericlesMachine::memoryGetOperandAddress()
 {
+    int immediateAddress = decodedImmediateAddress;
+    AddressingMode::AddressingModeCode addressingModeCode = decodedAdressingModeCode1;
+
+    
     switch (addressingModeCode)
     {
         case AddressingMode::DIRECT:

--- a/src/machines/periclesmachine.cpp
+++ b/src/machines/periclesmachine.cpp
@@ -94,7 +94,7 @@ void PericlesMachine::decodeInstruction(){
     }
 }
 
-int PericlesMachine::memoryGetOperandAddress()
+int PericlesMachine::GetCurrentOperandAddress()
 {
     int immediateAddress = decodedImmediateAddress;
     AddressingMode::AddressingModeCode addressingModeCode = decodedAdressingModeCode1;

--- a/src/machines/periclesmachine.h
+++ b/src/machines/periclesmachine.h
@@ -10,7 +10,7 @@ public:
 
     void decodeInstruction();
     virtual int calculateBytesToReserve(QString addressArgument);
-    virtual int memoryGetOperandAddress(); // increments accessCount
+    virtual int GetCurrentOperandAddress(); // increments accessCount
     virtual void getNextOperandAddress(int &intermediateAddress, int &intermediateAddress2, int &finalOperandAddress);
     virtual QString generateArgumentsString(int address, Instruction *instruction, AddressingMode::AddressingModeCode addressingModeCode, int &argumentsSize);
 

--- a/src/machines/periclesmachine.h
+++ b/src/machines/periclesmachine.h
@@ -8,9 +8,9 @@ class PericlesMachine : public Machine
 public:
     PericlesMachine();
 
-    virtual void decodeInstruction(int fetchedValue, Instruction *&instruction, AddressingMode::AddressingModeCode &addressingMode, QString &registerId, int &immediateAddress);
+    void decodeInstruction();
     virtual int calculateBytesToReserve(QString addressArgument);
-    virtual int memoryGetOperandAddress(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode); // increments accessCount
+    virtual int memoryGetOperandAddress(); // increments accessCount
     virtual void getNextOperandAddress(int &intermediateAddress, int &intermediateAddress2, int &finalOperandAddress);
     virtual QString generateArgumentsString(int address, Instruction *instruction, AddressingMode::AddressingModeCode addressingModeCode, int &argumentsSize);
 

--- a/src/machines/voltamachine.cpp
+++ b/src/machines/voltamachine.cpp
@@ -282,22 +282,22 @@ void VoltaMachine::executeInstruction()
         break;
 
     case Instruction::VOLTA_PSH:
-        value1 = memoryGetOperandValue();
+        value1 = GetCurrentOperandValue();
         stackPush(value1);
         break;
 
     case Instruction::VOLTA_POP:
         value1 = stackPop();
-        memoryWrite(memoryGetOperandAddress(), value1);
+        memoryWrite(GetCurrentOperandAddress(), value1);
         break;
 
     case Instruction::VOLTA_JMP:
-        setPCValue(memoryGetJumpAddress());
+        setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::VOLTA_JSR:
         stackPush(getPCValue());
-        setPCValue(memoryGetJumpAddress());
+        setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::VOLTA_HLT:

--- a/src/machines/voltamachine.cpp
+++ b/src/machines/voltamachine.cpp
@@ -74,11 +74,14 @@ VoltaMachine::VoltaMachine()
     addressingModes.append(new AddressingMode("......11", AddressingMode::INDEXED_BY_PC, "(.*),pc"));
 }
 
-void VoltaMachine::executeInstruction(Instruction *&instruction, AddressingMode::AddressingModeCode addressingModeCode, QString, int immediateAddress)
+void VoltaMachine::executeInstruction()
 {
     int value1, value2, result, bit;
     Instruction::InstructionCode instructionCode;
-    instructionCode = (instruction) ? instruction->getInstructionCode() : Instruction::NOP;
+    instructionCode = (currentInstruction) ? currentInstruction->getInstructionCode() : Instruction::NOP;
+
+    int immediateAddress = decodedImmediateAddress;
+    AddressingMode::AddressingModeCode addressingModeCode = decodedAdressingModeCode1;
 
     switch (instructionCode)
     {
@@ -279,22 +282,22 @@ void VoltaMachine::executeInstruction(Instruction *&instruction, AddressingMode:
         break;
 
     case Instruction::VOLTA_PSH:
-        value1 = memoryGetOperandValue(immediateAddress, addressingModeCode);
+        value1 = memoryGetOperandValue();
         stackPush(value1);
         break;
 
     case Instruction::VOLTA_POP:
         value1 = stackPop();
-        memoryWrite(memoryGetOperandAddress(immediateAddress, addressingModeCode), value1);
+        memoryWrite(memoryGetOperandAddress(), value1);
         break;
 
     case Instruction::VOLTA_JMP:
-        setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+        setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::VOLTA_JSR:
         stackPush(getPCValue());
-        setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+        setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::VOLTA_HLT:

--- a/src/machines/voltamachine.h
+++ b/src/machines/voltamachine.h
@@ -7,8 +7,8 @@ class VoltaMachine : public Machine
 {
 public:
     VoltaMachine();
-
-    virtual void executeInstruction(Instruction *&instruction, AddressingMode::AddressingModeCode addressingModeCode, QString, int immediateAddress);
+    
+    void executeInstruction();
     void skipNextInstruction();
 
     virtual void generateDescriptions();


### PR DESCRIPTION
## Descrição
Refatoração das funções fetch, decode and execute para descartar a necessidade de argumentos, agora argumentos fazem parte de atributos da classe machine. Mudança do nome de funções para refletirem melhor o respectivo funcionamento.

## Passos para testar
<!-- Caso seja uma correção, passos para reproduzir o bug no código original -->
<!-- Caso seja uma melhoria, passos para testar a mudança -->

## Observações
<!-- Informações adicionais ou pontos de cuidado para quem estiver revisando -->
