### PR TITLE
Quickfix Machine runtime parameters

### DIFF
--- a/src/core/machine.cpp
+++ b/src/core/machine.cpp
@@ -1067,8 +1067,12 @@ int Machine::memoryGetJumpAddress(int immediateAddress, AddressingMode::Addressi
 //////////////////////////////////////////////////
 
 // Returns true if successful
-FileErrorCode::FileErrorCode Machine::importMemory(QString filename)
+FileErrorCode::FileErrorCode Machine::importMemory(QString filename, int start, int end, int dest)
 {
+    if(start < 0 || end > memory.size()){
+        return FileErrorCode::invalidAddress;
+    }
+    
     char byte;
     QFile memFile(filename); // Implicitly closed
 
@@ -1094,7 +1098,10 @@ FileErrorCode::FileErrorCode Machine::importMemory(QString filename)
     }
 
     // Read memory
-    for (int address = 0; address < memory.size(); address++)
+    memFile.seek(1 + identifier.length() + (2 * start)); //Set loaded file read starting point
+    int read_size = qMin<int>(end - start, getMemorySize() - dest); //Put the maximum amount of bytes read possible
+
+    for (int address = dest; address < (dest + read_size); address++)
     {
         memFile.getChar(&byte);
         setMemoryValue(address, byte);

--- a/src/core/machine.cpp
+++ b/src/core/machine.cpp
@@ -76,6 +76,7 @@ void Machine::decodeInstruction()
 void Machine::executeInstruction()
 {
     int value1, value2, result;
+    int immediateAddress = decodedImmediateAddress;
     Instruction::InstructionCode instructionCode;
     instructionCode = (currentInstruction) ? currentInstruction->getInstructionCode() : Instruction::NOP;
     bool isImmediate = (decodedAdressingModeCode1 == AddressingMode::IMMEDIATE); // Used to invalidate immediate jumps
@@ -92,14 +93,14 @@ void Machine::executeInstruction()
     //////////////////////////////////////////////////
 
     case Instruction::LDR:
-        result = memoryGetOperandValue(immediateAddress, addressingModeCode);
+        result = memoryGetOperandValue();
         setRegisterValue(registerName, result);
         updateFlags(result);
         break;
 
     case Instruction::STR:
         result = getRegisterValue(registerName);
-        memoryWrite(memoryGetOperandAddress(immediateAddress, addressingModeCode), result);
+        memoryWrite(memoryGetOperandAddress(), result);
         break;
 
 
@@ -110,7 +111,7 @@ void Machine::executeInstruction()
 
     case Instruction::ADD:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue(immediateAddress, addressingModeCode);
+        value2 = memoryGetOperandValue();
         result = (value1 + value2) & 0xFF;
 
         setRegisterValue(registerName, result);
@@ -121,7 +122,7 @@ void Machine::executeInstruction()
 
     case Instruction::OR:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue(immediateAddress, addressingModeCode);
+        value2 = memoryGetOperandValue();
         result = (value1 | value2);
 
         setRegisterValue(registerName, result);
@@ -130,7 +131,7 @@ void Machine::executeInstruction()
 
     case Instruction::AND:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue(immediateAddress, addressingModeCode);
+        value2 = memoryGetOperandValue();
         result = (value1 & value2);
 
         setRegisterValue(registerName, result);
@@ -147,7 +148,7 @@ void Machine::executeInstruction()
 
     case Instruction::SUB:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue(immediateAddress, addressingModeCode);
+        value2 = memoryGetOperandValue();
         result = (value1 - value2) & 0xFF;
 
         setRegisterValue(registerName, result);
@@ -216,63 +217,63 @@ void Machine::executeInstruction()
 
     case Instruction::JMP:
         if (!isImmediate) // Invalidate immediate jumps
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JN:
         if (getFlagValue("N") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JP:
         if (getFlagValue("N") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JV:
         if (getFlagValue("V") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JNV:
         if (getFlagValue("V") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JZ:
         if (getFlagValue("Z") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JNZ:
         if (getFlagValue("Z") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JC:
         if (getFlagValue("C") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JNC:
         if (getFlagValue("C") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JB:
         if (getFlagValue("B") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JNB:
         if (getFlagValue("B") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+            setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::JSR:
         if (!isImmediate)
         {
-            int jumpAddress = memoryGetJumpAddress(immediateAddress, addressingModeCode);
+            int jumpAddress = memoryGetJumpAddress();
             memoryWrite(jumpAddress, getPCValue());
             setPCValue(jumpAddress+1);
         }
@@ -1026,8 +1027,12 @@ int Machine::memoryReadNext()
     return value;
 }
 
-int Machine::memoryGetOperandAddress(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode)
+int Machine::memoryGetOperandAddress()
 {
+
+    int immediateAddress = decodedImmediateAddress; 
+    AddressingMode::AddressingModeCode addressingModeCode = decodedAdressingModeCode1;
+
     switch (addressingModeCode)
     {
         case AddressingMode::DIRECT:
@@ -1050,14 +1055,14 @@ int Machine::memoryGetOperandAddress(int immediateAddress, AddressingMode::Addre
     }
 }
 
-int Machine::memoryGetOperandValue(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode)
+int Machine::memoryGetOperandValue()
 {
-    return memoryRead(memoryGetOperandAddress(immediateAddress, addressingModeCode)); // Return 1-byte value
+    return memoryRead(memoryGetOperandAddress()); // Return 1-byte value
 }
 
-int Machine::memoryGetJumpAddress(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode)
+int Machine::memoryGetJumpAddress()
 {
-    return memoryGetOperandAddress(immediateAddress, addressingModeCode);
+    return memoryGetOperandAddress();
 }
 
 

--- a/src/core/machine.cpp
+++ b/src/core/machine.cpp
@@ -93,14 +93,14 @@ void Machine::executeInstruction()
     //////////////////////////////////////////////////
 
     case Instruction::LDR:
-        result = memoryGetOperandValue();
+        result = GetCurrentOperandValue();
         setRegisterValue(registerName, result);
         updateFlags(result);
         break;
 
     case Instruction::STR:
         result = getRegisterValue(registerName);
-        memoryWrite(memoryGetOperandAddress(), result);
+        memoryWrite(GetCurrentOperandAddress(), result);
         break;
 
 
@@ -111,7 +111,7 @@ void Machine::executeInstruction()
 
     case Instruction::ADD:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue();
+        value2 = GetCurrentOperandValue();
         result = (value1 + value2) & 0xFF;
 
         setRegisterValue(registerName, result);
@@ -122,7 +122,7 @@ void Machine::executeInstruction()
 
     case Instruction::OR:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue();
+        value2 = GetCurrentOperandValue();
         result = (value1 | value2);
 
         setRegisterValue(registerName, result);
@@ -131,7 +131,7 @@ void Machine::executeInstruction()
 
     case Instruction::AND:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue();
+        value2 = GetCurrentOperandValue();
         result = (value1 & value2);
 
         setRegisterValue(registerName, result);
@@ -148,7 +148,7 @@ void Machine::executeInstruction()
 
     case Instruction::SUB:
         value1 = getRegisterValue(registerName);
-        value2 = memoryGetOperandValue();
+        value2 = GetCurrentOperandValue();
         result = (value1 - value2) & 0xFF;
 
         setRegisterValue(registerName, result);
@@ -217,63 +217,63 @@ void Machine::executeInstruction()
 
     case Instruction::JMP:
         if (!isImmediate) // Invalidate immediate jumps
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JN:
         if (getFlagValue("N") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JP:
         if (getFlagValue("N") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JV:
         if (getFlagValue("V") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JNV:
         if (getFlagValue("V") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JZ:
         if (getFlagValue("Z") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JNZ:
         if (getFlagValue("Z") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JC:
         if (getFlagValue("C") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JNC:
         if (getFlagValue("C") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JB:
         if (getFlagValue("B") == true && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JNB:
         if (getFlagValue("B") == false && !isImmediate)
-            setPCValue(memoryGetJumpAddress());
+            setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::JSR:
         if (!isImmediate)
         {
-            int jumpAddress = memoryGetJumpAddress();
+            int jumpAddress = GetCurrentJumpAddress();
             memoryWrite(jumpAddress, getPCValue());
             setPCValue(jumpAddress+1);
         }
@@ -1027,7 +1027,7 @@ int Machine::memoryReadNext()
     return value;
 }
 
-int Machine::memoryGetOperandAddress()
+int Machine::GetCurrentOperandAddress()
 {
 
     int immediateAddress = decodedImmediateAddress; 
@@ -1055,14 +1055,14 @@ int Machine::memoryGetOperandAddress()
     }
 }
 
-int Machine::memoryGetOperandValue()
+int Machine::GetCurrentOperandValue()
 {
-    return memoryRead(memoryGetOperandAddress()); // Return 1-byte value
+    return memoryRead(GetCurrentOperandAddress()); // Return 1-byte value
 }
 
-int Machine::memoryGetJumpAddress()
+int Machine::GetCurrentJumpAddress()
 {
-    return memoryGetOperandAddress();
+    return GetCurrentOperandAddress();
 }
 
 

--- a/src/core/machine.h
+++ b/src/core/machine.h
@@ -24,6 +24,7 @@ namespace FileErrorCode
         inputOutput,
         incorrectSize,
         invalidIdentifier,
+        invalidAddress
     };
 }
 
@@ -140,7 +141,7 @@ public:
     //////////////////////////////////////////////////
 
     ///Set up the machine's memory from a .mem file
-    FileErrorCode::FileErrorCode importMemory(QString filename);
+    FileErrorCode::FileErrorCode importMemory(QString filename, int start, int end, int dest);
     ///Save the machine's memory in a .mem file
     FileErrorCode::FileErrorCode exportMemory(QString filename);
 

--- a/src/core/machine.h
+++ b/src/core/machine.h
@@ -130,9 +130,9 @@ public:
     void memoryWrite(int address, int value); // Increments accessCount
     int  memoryReadNext(); // Returns value pointed to by PC, then increments PC; Increments accessCount
 
-    virtual int memoryGetOperandAddress(); // increments accessCount
-    int memoryGetOperandValue(); // increments accessCount
-    int memoryGetJumpAddress(); // increments accessCount
+    virtual int GetCurrentOperandAddress(); // increments accessCount
+    int GetCurrentOperandValue(); // increments accessCount
+    int GetCurrentJumpAddress(); // increments accessCount
 
 
 

--- a/src/core/machine.h
+++ b/src/core/machine.h
@@ -130,9 +130,9 @@ public:
     void memoryWrite(int address, int value); // Increments accessCount
     int  memoryReadNext(); // Returns value pointed to by PC, then increments PC; Increments accessCount
 
-    virtual int memoryGetOperandAddress(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode); // increments accessCount
-    int memoryGetOperandValue(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode); // increments accessCount
-    int memoryGetJumpAddress( int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode); // increments accessCount
+    virtual int memoryGetOperandAddress(); // increments accessCount
+    int memoryGetOperandValue(); // increments accessCount
+    int memoryGetJumpAddress(); // increments accessCount
 
 
 

--- a/src/gui/hidragui.h
+++ b/src/gui/hidragui.h
@@ -108,6 +108,7 @@ private slots:
     void on_actionRun_triggered();
     void on_actionStep_triggered();
     void on_actionImportMemory_triggered();
+    void on_actionImportMemoryPartial_triggered();
     void on_actionExportMemory_triggered();
     void on_actionResetRegisters_triggered();
     void on_actionSetBreakpoint_triggered();

--- a/src/gui/hidragui.ui
+++ b/src/gui/hidragui.ui
@@ -325,8 +325,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>275</width>
-               <height>68</height>
+               <width>279</width>
+               <height>75</height>
               </rect>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -697,7 +697,7 @@
      <x>0</x>
      <y>0</y>
      <width>1115</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuProgram">
@@ -733,6 +733,7 @@
     <addaction name="actionSetBreakpoint"/>
     <addaction name="separator"/>
     <addaction name="actionImportMemory"/>
+    <addaction name="actionImportMemoryPartial"/>
     <addaction name="actionExportMemory"/>
    </widget>
    <widget class="QMenu" name="menuView">
@@ -1054,6 +1055,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+F</string>
+   </property>
+  </action>
+  <action name="actionImportMemoryPartial">
+   <property name="text">
+    <string>Carga parcial...</string>
    </property>
   </action>
  </widget>

--- a/src/machines/periclesmachine.cpp
+++ b/src/machines/periclesmachine.cpp
@@ -78,24 +78,28 @@ int PericlesMachine::calculateBytesToReserve(QString addressArgument)
     return (addressingModeCode == AddressingMode::IMMEDIATE) ? 2 : 3; // Immediate requires only 2 bytes
 }
 
-void PericlesMachine::decodeInstruction(int fetchedValue, Instruction *&instruction, AddressingMode::AddressingModeCode &addressingModeCode, QString &registerName, int &immediateAddress)
-{
-    addressingModeCode = extractAddressingModeCode(fetchedValue);
-    registerName = extractRegisterName(fetchedValue);
+void PericlesMachine::decodeInstruction(){
+    
+    decodedAdressingModeCode1 = extractAddressingModeCode(fetchedValue);
+    decodedRegisterName1 = extractRegisterName(fetchedValue);
 
-    if (instruction && instruction->getNumBytes() == 0) // If instruction has variable number of bytes
+    if (currentInstruction && currentInstruction->getNumBytes() == 0) // If instruction has variable number of bytes
     {
-        immediateAddress = getPCValue(); // Address that contains first argument byte
+        decodedImmediateAddress = getPCValue(); // Address that contains first argument byte
 
         // Skip argument bytes
         incrementPCValue();
-        if (addressingModeCode != AddressingMode::IMMEDIATE) // Immediate argument has only 1 byte
+        if (decodedAdressingModeCode1 != AddressingMode::IMMEDIATE) // Immediate argument has only 1 byte
             incrementPCValue();
     }
 }
 
-int PericlesMachine::memoryGetOperandAddress(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode)
+int PericlesMachine::memoryGetOperandAddress()
 {
+    int immediateAddress = decodedImmediateAddress;
+    AddressingMode::AddressingModeCode addressingModeCode = decodedAdressingModeCode1;
+
+    
     switch (addressingModeCode)
     {
         case AddressingMode::DIRECT:

--- a/src/machines/periclesmachine.cpp
+++ b/src/machines/periclesmachine.cpp
@@ -94,7 +94,7 @@ void PericlesMachine::decodeInstruction(){
     }
 }
 
-int PericlesMachine::memoryGetOperandAddress()
+int PericlesMachine::GetCurrentOperandAddress()
 {
     int immediateAddress = decodedImmediateAddress;
     AddressingMode::AddressingModeCode addressingModeCode = decodedAdressingModeCode1;

--- a/src/machines/periclesmachine.h
+++ b/src/machines/periclesmachine.h
@@ -10,7 +10,7 @@ public:
 
     void decodeInstruction();
     virtual int calculateBytesToReserve(QString addressArgument);
-    virtual int memoryGetOperandAddress(); // increments accessCount
+    virtual int GetCurrentOperandAddress(); // increments accessCount
     virtual void getNextOperandAddress(int &intermediateAddress, int &intermediateAddress2, int &finalOperandAddress);
     virtual QString generateArgumentsString(int address, Instruction *instruction, AddressingMode::AddressingModeCode addressingModeCode, int &argumentsSize);
 

--- a/src/machines/periclesmachine.h
+++ b/src/machines/periclesmachine.h
@@ -8,9 +8,9 @@ class PericlesMachine : public Machine
 public:
     PericlesMachine();
 
-    virtual void decodeInstruction(int fetchedValue, Instruction *&instruction, AddressingMode::AddressingModeCode &addressingMode, QString &registerId, int &immediateAddress);
+    void decodeInstruction();
     virtual int calculateBytesToReserve(QString addressArgument);
-    virtual int memoryGetOperandAddress(int immediateAddress, AddressingMode::AddressingModeCode addressingModeCode); // increments accessCount
+    virtual int memoryGetOperandAddress(); // increments accessCount
     virtual void getNextOperandAddress(int &intermediateAddress, int &intermediateAddress2, int &finalOperandAddress);
     virtual QString generateArgumentsString(int address, Instruction *instruction, AddressingMode::AddressingModeCode addressingModeCode, int &argumentsSize);
 

--- a/src/machines/voltamachine.cpp
+++ b/src/machines/voltamachine.cpp
@@ -282,22 +282,22 @@ void VoltaMachine::executeInstruction()
         break;
 
     case Instruction::VOLTA_PSH:
-        value1 = memoryGetOperandValue();
+        value1 = GetCurrentOperandValue();
         stackPush(value1);
         break;
 
     case Instruction::VOLTA_POP:
         value1 = stackPop();
-        memoryWrite(memoryGetOperandAddress(), value1);
+        memoryWrite(GetCurrentOperandAddress(), value1);
         break;
 
     case Instruction::VOLTA_JMP:
-        setPCValue(memoryGetJumpAddress());
+        setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::VOLTA_JSR:
         stackPush(getPCValue());
-        setPCValue(memoryGetJumpAddress());
+        setPCValue(GetCurrentJumpAddress());
         break;
 
     case Instruction::VOLTA_HLT:

--- a/src/machines/voltamachine.cpp
+++ b/src/machines/voltamachine.cpp
@@ -74,11 +74,14 @@ VoltaMachine::VoltaMachine()
     addressingModes.append(new AddressingMode("......11", AddressingMode::INDEXED_BY_PC, "(.*),pc"));
 }
 
-void VoltaMachine::executeInstruction(Instruction *&instruction, AddressingMode::AddressingModeCode addressingModeCode, QString, int immediateAddress)
+void VoltaMachine::executeInstruction()
 {
     int value1, value2, result, bit;
     Instruction::InstructionCode instructionCode;
-    instructionCode = (instruction) ? instruction->getInstructionCode() : Instruction::NOP;
+    instructionCode = (currentInstruction) ? currentInstruction->getInstructionCode() : Instruction::NOP;
+
+    int immediateAddress = decodedImmediateAddress;
+    AddressingMode::AddressingModeCode addressingModeCode = decodedAdressingModeCode1;
 
     switch (instructionCode)
     {
@@ -279,22 +282,22 @@ void VoltaMachine::executeInstruction(Instruction *&instruction, AddressingMode:
         break;
 
     case Instruction::VOLTA_PSH:
-        value1 = memoryGetOperandValue(immediateAddress, addressingModeCode);
+        value1 = memoryGetOperandValue();
         stackPush(value1);
         break;
 
     case Instruction::VOLTA_POP:
         value1 = stackPop();
-        memoryWrite(memoryGetOperandAddress(immediateAddress, addressingModeCode), value1);
+        memoryWrite(memoryGetOperandAddress(), value1);
         break;
 
     case Instruction::VOLTA_JMP:
-        setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+        setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::VOLTA_JSR:
         stackPush(getPCValue());
-        setPCValue(memoryGetJumpAddress(immediateAddress, addressingModeCode));
+        setPCValue(memoryGetJumpAddress());
         break;
 
     case Instruction::VOLTA_HLT:

--- a/src/machines/voltamachine.h
+++ b/src/machines/voltamachine.h
@@ -7,8 +7,8 @@ class VoltaMachine : public Machine
 {
 public:
     VoltaMachine();
-
-    virtual void executeInstruction(Instruction *&instruction, AddressingMode::AddressingModeCode addressingModeCode, QString, int immediateAddress);
+    
+    void executeInstruction();
     void skipNextInstruction();
 
     virtual void generateDescriptions();


### PR DESCRIPTION
## Descrição
<!-- Descreva aqui em detalhes as mudanças introduzidas por esse Pull Request -->
Quickfix dos erros introduzidos pelo PR #32; agora máquinas tem parâmetros das funções fetch-decode-execute como atributos e foram renomeadas algumas funções refatoradas de forma a refletir seus comportamentos

## Passos para testar
<!-- Caso seja uma correção, passos para reproduzir o bug no código original -->
<!-- Caso seja uma melhoria, passos para testar a mudança -->

## Observações
<!-- Informações adicionais ou pontos de cuidado para quem estiver revisando -->
