### PR TITLE
Dark mode

### DIFF
--- a/src/gui/hidracodeeditor.cpp
+++ b/src/gui/hidracodeeditor.cpp
@@ -76,7 +76,7 @@ void HidraCodeEditor::highlightCurrentLine()
     if (!isReadOnly()) {
         QTextEdit::ExtraSelection selection;
 
-        QColor lineColor = QColor(240, 240, 240);
+        QColor lineColor = QColor(30, 30, 30);
 
         selection.format.setBackground(lineColor);
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
@@ -101,7 +101,7 @@ void HidraCodeEditor::highlightPCLine(int pcLine)
         {
             QTextEdit::ExtraSelection selection;
 
-            QColor lineColor = QColor(255, 244, 128); // Yellow
+            QColor lineColor = QColor(255, 244, 128, 60); // Yellow (with some transparency)
 
             selection.format.setBackground(lineColor);
             selection.format.setProperty(QTextFormat::FullWidthSelection, true);
@@ -230,7 +230,7 @@ void HidraCodeEditor::clear()
 void HidraCodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event)
 {
     QPainter painter(lineNumberArea);
-    painter.fillRect(event->rect(), QColor(240, 240, 240)); // Light gray
+    painter.fillRect(event->rect(), QColor(57, 57, 57)); // Same as window, but slightly lighter
 
     QTextBlock block = firstVisibleBlock();
     int blockNumber = block.blockNumber();
@@ -254,7 +254,7 @@ void HidraCodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event)
         {
             QString number = QString::number(blockNumber + 1);
             bool onCursorLine = (blockNumber == textCursor().blockNumber());
-            painter.setPen(onCursorLine ? QColor(64, 64, 64) : QColor(128, 128, 128)); // Dark gray (darker for cursor line)
+            painter.setPen(onCursorLine ? QColor(240, 240, 240) : QColor(160, 160, 160)); // Light gray (lighter for cursor line)
             painter.drawText(0, top, lineNumberArea->width() - 1, fontMetrics().height(), Qt::AlignRight, number);
         }
 

--- a/src/gui/hidragui.cpp
+++ b/src/gui/hidragui.cpp
@@ -188,7 +188,6 @@ void HidraGui::loadConfFile()
 }
 
 
-
 //////////////////////////////////////////////////
 // Internal initialize methods
 //////////////////////////////////////////////////
@@ -1001,6 +1000,38 @@ void HidraGui::enableStatusBarSignal()
 void HidraGui::disableStatusBarSignal()
 {
     disconnect(ui->statusBar, SIGNAL(messageChanged(QString)), this, SLOT(statusBarMessageChanged(QString)));
+}
+
+// Creates a dark mode palette
+QPalette HidraGui::getDarkModePalette()
+{
+
+  QPalette palette;
+  palette.setColor(QPalette::Window, QColor(53, 53, 53));
+  palette.setColor(QPalette::WindowText, Qt::white);
+  palette.setColor(QPalette::Disabled, QPalette::WindowText,
+                   QColor(127, 127, 127));
+  palette.setColor(QPalette::Base, QColor(42, 42, 42));
+  palette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
+  palette.setColor(QPalette::ToolTipBase, Qt::white);
+  palette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
+  palette.setColor(QPalette::Text, Qt::white);
+  palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+  palette.setColor(QPalette::Dark, QColor(35, 35, 35));
+  palette.setColor(QPalette::Shadow, QColor(20, 20, 20));
+  palette.setColor(QPalette::Button, QColor(53, 53, 53));
+  palette.setColor(QPalette::ButtonText, Qt::white);
+  palette.setColor(QPalette::Disabled, QPalette::ButtonText,
+                   QColor(127, 127, 127));
+  palette.setColor(QPalette::BrightText, Qt::red);
+  palette.setColor(QPalette::Link, QColor(42, 130, 218));
+  palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+  palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+  palette.setColor(QPalette::HighlightedText, Qt::white);
+  palette.setColor(QPalette::Disabled, QPalette::HighlightedText,
+                   QColor(127, 127, 127));
+  return palette;
+
 }
 
 void HidraGui::clearErrorsField()

--- a/src/gui/hidragui.cpp
+++ b/src/gui/hidragui.cpp
@@ -380,7 +380,7 @@ void HidraGui::initializeInstructionsList()
     {
         QLabel *instructionText = new QLabel(this);
         instructionText->setTextFormat(Qt::RichText);
-
+        
         // Label text
         instructionText->setText(instruction->getMnemonic().toUpper());
 
@@ -585,13 +585,13 @@ void HidraGui::updateMemoryTable(bool force, bool updateInstructionStrings)
 
         // Get new color
         if (sourceAndMemoryInSync && row == finalOperandAddress)
-            rowColor = QColor(255, 202, 176); // Red
+            rowColor = QColor(255, 202, 176, 60); // Red
         else if (sourceAndMemoryInSync && (row == intermediateAddress || row == intermediateAddress2))
-            rowColor = QColor(255, 228, 148); // Orange
+            rowColor = QColor(255, 228, 148, 60); // Orange
         else if (sourceAndMemoryInSync && currentLine == machine->getAddressCorrespondingSourceLine(row) && currentLine >= 0)
-            rowColor = QColor(255, 244, 128); // Yellow
+            rowColor = QColor(255, 244, 128, 60); // Yellow
         else
-            rowColor = Qt::white;
+            rowColor = QColor(30, 30, 30); //Must be same as base TO-DO Palette must be held by class
 
         // Update row color if needed
         if (previousRowColor[row] != rowColor)
@@ -649,7 +649,7 @@ void HidraGui::updateStackTable()
         // Column 2: Byte value
         //////////////////////////////////////////////////
 
-        stackModel.item(row, ColumnStackValue)->setForeground((stackAddress > spValue) ? colorGrayedOut : Qt::black); // Inaccessible stack items grayed out
+        stackModel.item(row, ColumnStackValue)->setForeground((stackAddress > spValue) ? colorGrayedOut : Qt::white); // Inaccessible stack items grayed out TO-DO: USE PALETTE
         stackModel.item(row, ColumnStackValue)->setText(valueToString(value, showHexValues, showSignedData));
     }
 
@@ -1006,31 +1006,31 @@ void HidraGui::disableStatusBarSignal()
 QPalette HidraGui::getDarkModePalette()
 {
 
-  QPalette palette;
-  palette.setColor(QPalette::Window, QColor(53, 53, 53));
-  palette.setColor(QPalette::WindowText, Qt::white);
-  palette.setColor(QPalette::Disabled, QPalette::WindowText,
-                   QColor(127, 127, 127));
-  palette.setColor(QPalette::Base, QColor(42, 42, 42));
-  palette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
-  palette.setColor(QPalette::ToolTipBase, Qt::white);
-  palette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
-  palette.setColor(QPalette::Text, Qt::white);
-  palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
-  palette.setColor(QPalette::Dark, QColor(35, 35, 35));
-  palette.setColor(QPalette::Shadow, QColor(20, 20, 20));
-  palette.setColor(QPalette::Button, QColor(53, 53, 53));
-  palette.setColor(QPalette::ButtonText, Qt::white);
-  palette.setColor(QPalette::Disabled, QPalette::ButtonText,
-                   QColor(127, 127, 127));
-  palette.setColor(QPalette::BrightText, Qt::red);
-  palette.setColor(QPalette::Link, QColor(42, 130, 218));
-  palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
-  palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
-  palette.setColor(QPalette::HighlightedText, Qt::white);
-  palette.setColor(QPalette::Disabled, QPalette::HighlightedText,
-                   QColor(127, 127, 127));
-  return palette;
+    QPalette palette;
+    palette.setColor(QPalette::Window, QColor(53, 53, 53));
+    palette.setColor(QPalette::WindowText, Qt::white);
+    palette.setColor(QPalette::Inactive, QPalette::ToolTipText, Qt::white);
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));
+    palette.setColor(QPalette::Base, QColor(30, 30, 30));
+    palette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
+    palette.setColor(QPalette::ToolTipBase, Qt::white);
+    palette.setColor(QPalette::ToolTipText, Qt::white);
+    palette.setColor(QPalette::Text, Qt::white);
+    palette.setColor(QPalette::PlaceholderText, Qt::red);
+    palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+    palette.setColor(QPalette::Dark, QColor(35, 35, 35));
+    palette.setColor(QPalette::Shadow, QColor(20, 20, 20));
+    palette.setColor(QPalette::Button, QColor(53, 53, 53));
+    palette.setColor(QPalette::ButtonText, Qt::white);
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127));
+    palette.setColor(QPalette::BrightText, Qt::red);
+    palette.setColor(QPalette::Link, QColor(42, 130, 218));
+    palette.setColor(QPalette::Highlight, QColor(170, 170, 170, 80));
+    palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+    palette.setColor(QPalette::HighlightedText, Qt::white);
+    palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127));
+    palette.setColor(QPalette::NoRole, Qt::red);
+    return palette;
 
 }
 

--- a/src/gui/hidragui.h
+++ b/src/gui/hidragui.h
@@ -12,6 +12,7 @@
 #include <QVector>
 #include <QColor>
 #include <QSettings>
+#include <QPalette>
 
 #include "hidracodeeditor.h"
 #include "hidrahighlighter.h"
@@ -78,6 +79,10 @@ public:
     void disableDataChangedSignal();
     void enableStatusBarSignal();
     void disableStatusBarSignal();
+
+    // Qt palette configurations
+    static QPalette getDarkModePalette();
+
 
 public slots:
     void selectMachine(QString machineName);
@@ -221,6 +226,9 @@ private:
     bool showHexValues, showSignedData, showCharacters; // Value display modes
     bool fastExecute; // Don't update memory table on every instruction
     bool followPC;
+
+
+    
 };
 
 #endif // HIDRAGUI_H

--- a/src/gui/hidrahighlighter.cpp
+++ b/src/gui/hidrahighlighter.cpp
@@ -76,7 +76,8 @@ void HidraHighlighter::initializeInstructionHighlightRule(Machine &machine)
     QTextCharFormat instructionsFormat;
 
     instructionsFormat.setFontWeight(QFont::Bold);
-    instructionsFormat.setForeground(Qt::darkMagenta);
+    //instructionsFormat.setForeground(Qt::darkMagenta);
+    instructionsFormat.setForeground(QColor(237, 175, 2));
 
     // Append to list of rules
     highlightRulesList.push_back(HighlightRule(instructionsPattern, instructionsFormat));
@@ -100,7 +101,7 @@ void HidraHighlighter::initializeDirectivesHighlightRule()
     QTextCharFormat directivesFormat;
 
     directivesFormat.setFontWeight(QFont::Bold);
-    directivesFormat.setForeground(Qt::blue);
+    directivesFormat.setForeground(QColor(68, 119, 176));
 
     // Append to list of rules
     highlightRulesList.push_back(HighlightRule(directivesPattern, directivesFormat));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
  *******************************************************************************/
 
 #include <QApplication>
+#include <QPalette>
 #include "gui/hidragui.h"
 
 int main(int argc, char *argv[])
@@ -22,6 +23,13 @@ int main(int argc, char *argv[])
     a.setApplicationName("Hidra");
 
     HidraGui w;
+
+    QPalette dark_mode = HidraGui::getDarkModePalette();
+
+    // Dark mode configuration
+    a.setStyle("Fusion");
+    a.setPalette(dark_mode);
+    a.setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
 
     if (argc == 2)
         w.load(QString(argv[1]), false); // Load file


### PR DESCRIPTION
## Descrição
<!-- Descreva aqui em detalhes as mudanças introduzidas por esse Pull Request -->
Muda o tema padrão do Hidra para escuro. Para segurança de todos, não é possível voltar pro branco.

## Passos para testar
<!-- Caso seja uma correção, passos para reproduzir o bug no código original -->
<!-- Caso seja uma melhoria, passos para testar a mudança -->
Abra o hidra (versão antiga)
Abra o hidra (novo)
Veja como está melhor

## Observações
<!-- Informações adicionais ou pontos de cuidado para quem estiver revisando -->
Apesar do tema branco ser detestável, talvez seja bom fazer um toggle
Também é interessante tornar a lógica relacionada à escolha de temas mais robustas (atualmente é bem simples e hardcoded)

![image](https://user-images.githubusercontent.com/81876180/234470685-bd97cf3b-6a52-4951-ae1d-bd9996c10ee9.png)

![image](https://user-images.githubusercontent.com/81876180/234470864-ff7ef3ea-f034-4155-aa83-0a7683e7d571.png)

